### PR TITLE
Change reference link from personal repo to official Javis.jl repo

### DIFF
--- a/_assets/scripts/gravities.jl
+++ b/_assets/scripts/gravities.jl
@@ -3,7 +3,7 @@ using GLMakie, FileIO
 GLMakie.activate!()
 # See following links for references:
 # https://twitter.com/AnsonBiggs/status/1444823816031510529/photo/1
-# https://gitlab.com/MisterBiggs/gravities-of-the-solar-system/-/blob/master/gravities.jl
+# https://github.com/JuliaAnimators/Javis.jl/blob/master/examples/gravities.jl
 let
 
     diameters = Dict(


### PR DESCRIPTION
The code referenced was eventually pulled into the official Javis.jl repo so I think it makes more sense to link directly to them!

Love the Makie implementation!